### PR TITLE
:wrench: ci: add release please github action workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: "Release"
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  checks: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          command: manifest


### PR DESCRIPTION
Adds a CI workflow to automate github releases, tags, and version bumps.

Depends on https://github.com/linc-technologies/ember-tinymce/pull/12